### PR TITLE
Change Usage Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
 use Spatie\GuzzleRateLimiterMiddleware\RateLimiterMiddleware;
 
-$stack = HandlerStack::create(
-    RateLimiterMiddleware::perSecond(3)
-);
+$stack = HandlerStack::create();
+$stack->push(RateLimiterMiddleware::perSecond(3));
 
 $client = new Client([
     'handler' => $stack,


### PR DESCRIPTION
Following the example in the readme I was getting the following error.
```
   Symfony\Component\Debug\Exception\FatalThrowableError  : Argument 1 passed to Spatie\GuzzleRateLimiterMiddleware\RateLimiterMiddleware::__invoke() must be callable, object given, called in /home/vagrant/code/vendor/guzzlehttp/guzzle/src/PrepareBodyMiddleware.php on line 37
```
I think this is because RateLimiterMiddleware is a middleware class and not a handler class and has to be added to the stack via the "push" method http://docs.guzzlephp.org/en/stable/handlers-and-middleware.html

Thanks for the code.