### PR TITLE
Use usleep to ensure sleep actually happens

### DIFF
--- a/src/SleepDeferrer.php
+++ b/src/SleepDeferrer.php
@@ -11,6 +11,6 @@ class SleepDeferrer implements Deferrer
 
     public function sleep(int $milliseconds)
     {
-        sleep($milliseconds / 1000);
+        usleep($milliseconds * 1000);
     }
 }


### PR DESCRIPTION
## Description
Currently, since the PHP `sleep` function accepts integer durations, any sleep request under 1000ms isn't sleeping at all. With the current implementation the `perSecond` rate limiting is completely non-functional, since every sleep request is under 1000ms.