### PR TITLE
return an integer in SleepDeferrer->getCurrentTime

### DIFF
--- a/src/SleepDeferrer.php
+++ b/src/SleepDeferrer.php
@@ -6,7 +6,7 @@ class SleepDeferrer implements Deferrer
 {
     public function getCurrentTime(): int
     {
-        return round(microtime(true) * 1000);
+        return (int) round(microtime(true) * 1000);
     }
 
     public function sleep(int $milliseconds)


### PR DESCRIPTION
because according to [php documentation](https://www.php.net/manual/en/function.round.php) `round()` returns a float

on PHP v7.3.2 Windows this throws an exception:

```
 Symfony\Component\Debug\Exception\FatalThrowableError  : Return value of Spatie\GuzzleRateLimiterMiddleware\SleepDeferrer::getCurrentTime() must be of the type int, float returned

  at C:\xampp\httpdocs\vendor\spatie\guzzle-rate-limiter-middleware\src\SleepDeferrer.php:9
     5| class SleepDeferrer implements Deferrer
     6| {
     7|     public function getCurrentTime(): int
     8|     {
  >  9|         return round(microtime(true) * 1000);
    10|     }
    11|
    12|     public function sleep(int $milliseconds)
    13|     {
```