### PR TITLE
Added missing limit param to store interface to fix #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ class RateLimiterStore implements Store
         return Cache::get('rate-limiter', []);
     }
 
-    public function push(int $timestamp)
+    public function push(int $timestamp, int $limit)
     {
         Cache::put('rate-limiter', array_merge($this->get(), [$timestamp]));
     }

--- a/src/InMemoryStore.php
+++ b/src/InMemoryStore.php
@@ -12,7 +12,7 @@ class InMemoryStore implements Store
         return $this->timestamps;
     }
 
-    public function push(int $timestamp)
+    public function push(int $timestamp, int $limit)
     {
         $this->timestamps[] = $timestamp;
     }

--- a/src/Store.php
+++ b/src/Store.php
@@ -6,5 +6,5 @@ interface Store
 {
     public function get(): array;
 
-    public function push(int $timestamp, $limit);
+    public function push(int $timestamp, int $limit);
 }

--- a/src/Store.php
+++ b/src/Store.php
@@ -6,5 +6,5 @@ interface Store
 {
     public function get(): array;
 
-    public function push(int $timestamp);
+    public function push(int $timestamp, $limit);
 }


### PR DESCRIPTION
This is unfortunately going to be a breaking change, but it resolves an issue with store implementations that can't access the limit param that is being passed into the `push()` method via the `RateLimiter` class as #8 described.

You can find the arguments that pass the limit param here:
https://github.com/spatie/guzzle-rate-limiter-middleware/blob/master/src/RateLimiter.php#L42-L44

This might also benefit #11 by allowing them to use the limit in a custom store with atomic locks using the limit value.