### PR TITLE
Allow passing in deferrer to static timeframe methods

### DIFF
--- a/src/RateLimiterMiddleware.php
+++ b/src/RateLimiterMiddleware.php
@@ -14,25 +14,25 @@ class RateLimiterMiddleware
         $this->rateLimiter = $rateLimiter;
     }
 
-    public static function perSecond(int $limit, Store $store = null): RateLimiterMiddleware
+    public static function perSecond(int $limit, Store $store = null, Deferrer $deferrer = null): RateLimiterMiddleware
     {
         $rateLimiter = new RateLimiter(
             $limit,
             RateLimiter::TIME_FRAME_SECOND,
             $store ?? new InMemoryStore(),
-            new SleepDeferrer()
+            $deferrer ?? new SleepDeferrer()
         );
 
         return new static($rateLimiter);
     }
 
-    public static function perMinute(int $limit, Store $store = null): RateLimiterMiddleware
+    public static function perMinute(int $limit, Store $store = null, Deferrer $deferrer = null): RateLimiterMiddleware
     {
         $rateLimiter = new RateLimiter(
             $limit,
             RateLimiter::TIME_FRAME_MINUTE,
             $store ?? new InMemoryStore(),
-            new SleepDeferrer()
+            $deferrer ?? new SleepDeferrer()
         );
 
         return new static($rateLimiter);


### PR DESCRIPTION
Makes it easier than initializing a custom rate limiter just to override the deferrer instance.