### PR TITLE
Update README.MD (Laravel example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@ class RateLimiterStore implements Store
         return Cache::get('rate-limiter', []);
     }
 
-    public function push(int $timestamp, int $limit)
+    public function push(int $timestamp, int $limit): void
     {
-        Cache::put('rate-limiter', array_merge($this->get(), [$timestamp]));
+        $current = array_slice($this->get(), -($limit + 1));
+        $current[] = $timestamp;
+
+        Cache::put('rate-limiter', $current, 61);
     }
 }
 ```


### PR DESCRIPTION
Old example for laravel leads to out of memory php fatal errors - because it doesn't limit the number of stored items and at the same time doesn't have ttl, so cache is remembered forever.
More than that, thanks to use of array_merge that leads to x2 memory usage (actually x3 because of inner Cache::put realization). So if your cache will have so much data what it weights about 100mb, php will require 300mb of memory during execution of old push method

![image](https://user-images.githubusercontent.com/16332716/152540361-9385f084-2b3e-4c22-be65-4e2539920ccf.png)
