### PR TITLE
Add custom interval support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ RateLimiterMiddleware::perSecond(3); // Max. 3 requests per second
 RateLimiterMiddleware::perMinute(5); // Max. 5 requests per minute
 ```
 
+Or with a custom interval in milliseconds.
+
+```php
+RateLimiterMiddleware::customInterval(7, 10 * 1000); // Max. 7 requests per 10 seconds
+```
+
 ## Custom stores
 
 By default, the rate limiter works in memory. This means that if you have a second PHP process (or Guzzle client) consuming the same API, you'd still possibly hit the rate limit. To work around this issue, the rate limiter's state should be persisted to a cache. Implement the `Store` interface with your own cache, and pass the store to the rate limiter.

--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -74,6 +74,14 @@ class RateLimiter
             return 60 * 1000;
         }
 
+        if ($this->timeFrame === self::TIME_FRAME_SECOND) {
+            return 1000;
+        }
+
+        if (($timeFrame = intval($this->timeFrame)) !== 0) {
+            return $timeFrame;
+        }
+
         return 1000;
     }
 }

--- a/src/RateLimiterMiddleware.php
+++ b/src/RateLimiterMiddleware.php
@@ -38,6 +38,18 @@ class RateLimiterMiddleware
         return new static($rateLimiter);
     }
 
+    public static function customInterval(int $limit, int $timeFrameMs, ?Store $store = null, ?Deferrer $deferrer = null): RateLimiterMiddleware
+    {
+        $rateLimiter = new RateLimiter(
+            $limit,
+            strval($timeFrameMs),
+            $store ?? new InMemoryStore(),
+            $deferrer ?? new SleepDeferrer()
+        );
+
+        return new static($rateLimiter);
+    }
+
     public function __invoke(callable $handler)
     {
         return function (RequestInterface $request, array $options) use ($handler) {

--- a/tests/RateLimiterMiddlewareTest.php
+++ b/tests/RateLimiterMiddlewareTest.php
@@ -18,5 +18,10 @@ class RateLimiterMiddlewareTest extends TestCase
             RateLimiterMiddleware::class,
             RateLimiterMiddleware::perMinute(5)
         );
+
+        $this->assertInstanceOf(
+            RateLimiterMiddleware::class,
+            RateLimiterMiddleware::customInterval(5, 10000)
+        );
     }
 }

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -135,4 +135,66 @@ class RateLimiterTest extends TestCase
 
         $this->assertEquals(60000, $this->deferrer->getCurrentTime());
     }
+
+    /** @test */
+    public function it_execute_actions_below_a_limit_in_custom_interval()
+    {
+        $rateLimiter = $this->createRateLimiter(3, '10000');
+
+        $this->assertEquals(0, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+            $this->deferrer->sleep(100);
+        });
+
+        $this->assertEquals(100, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+            $this->deferrer->sleep(100);
+        });
+
+        $this->assertEquals(200, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+            $this->deferrer->sleep(100);
+        });
+
+        $this->assertEquals(300, $this->deferrer->getCurrentTime());
+
+        $this->deferrer->sleep(9700);
+
+        $rateLimiter->handle(function () {
+            $this->deferrer->sleep(100);
+        });
+
+        $this->assertEquals(10100, $this->deferrer->getCurrentTime());
+    }
+
+    /** @test */
+    public function it_defers_actions_when_it_reaches_a_limit_in_custom_interval()
+    {
+        $rateLimiter = $this->createRateLimiter(3, '10000');
+
+        $this->assertEquals(0, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+        });
+
+        $this->assertEquals(0, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+        });
+
+        $this->assertEquals(0, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+        });
+
+        $this->assertEquals(0, $this->deferrer->getCurrentTime());
+
+        $rateLimiter->handle(function () {
+        });
+
+        $this->assertEquals(10000, $this->deferrer->getCurrentTime());
+    }
 }


### PR DESCRIPTION
Adds support for custom time frame without changes to the __constructor() method for backwards compatibility. Also retains php 7.1 support